### PR TITLE
Fix Grade::set_out_of bug

### DIFF
--- a/src/grade.rs
+++ b/src/grade.rs
@@ -117,7 +117,7 @@ impl Grade {
     pub fn set_out_of(mut self,
                       out_of: f64)
                       -> Self {
-        self.grade = out_of;
+        self.out_of = out_of;
         self
     }
 }


### PR DESCRIPTION
## Summary
- correct the `set_out_of` method in `Grade` so it sets `out_of` instead of `grade`

## Testing
- `cargo check` *(fails: failed to get `async-openai` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684cd19b33c08331879f9edc93f90d83